### PR TITLE
feat:vscode: add ability to select labs

### DIFF
--- a/labs/.vscode/tasks.json
+++ b/labs/.vscode/tasks.json
@@ -41,7 +41,7 @@
 			"osx": {
 				"command": "${input:zephyrVenv}/bin/west"
 			},
-			"args": ["build", "-p", "-b", "${input:board}", "${fileDirname}/.."],
+			"args": ["build", "-p", "-b", "${input:board}", "${input:lab}"],
 			"problemMatcher": [
 				"$gcc"
 			]
@@ -143,6 +143,28 @@
 				"native_sim/native/64",
 				"nrf52840dk/nrf52840",
 				"qemu_cortex_m3"
+			]
+		},
+		{
+			"id": "lab",
+			"type": "pickString",
+			"description": "Which Lab to compile",
+			"options": [
+				"lab01",
+				"lab03",
+				"lab06",
+				"lab07",
+				"lab08",
+				"lab09",
+				"lab10",
+				"lab11",
+				"lab13",
+				"lab14",
+				"lab16",
+				"lab17",
+				"lab18",
+				"lab20",
+				"lab22",
 			]
 		},
 		{


### PR DESCRIPTION
currently the west custom build requires main.c to be focused in order to determine which lab to compile. This can be error prone during training, and is often overlooked.

a way around this would be select the lab as an input option when running the task

tested with labs, able to select and compile different labs without having a specific file in focus